### PR TITLE
Base64.decode trailing pad check fix

### DIFF
--- a/src/main/java/walkingkooka/j2cl/java/util/Base64.java
+++ b/src/main/java/walkingkooka/j2cl/java/util/Base64.java
@@ -391,7 +391,7 @@ public final class Base64 implements PublicStaticHelper {
                             mode = MODE_OCTET_0;
                             break;
                         case MODE_PAD:
-                            if (c == PAD) {
+                            if (c != PAD) {
                                 throw new IllegalArgumentException("Expected pad but got 0x" + Integer.toHexString(c) + " at " + i);
                             }
                             break;


### PR DESCRIPTION
- Also fixes lgtm warning "Useless comparison test".
- Added roundtrip tests for all encoder/decoders.